### PR TITLE
ADDED: Fixed typo in README.md file at Webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ server:
       secret_token: <a_secret_token>
 ```
 
-A complete example is available here: [examples/webhooks](examples/webhooks/README.md). You can also refer to the [configuration syntax](docs/configuration_syntax.md) for me information.
+A complete example is available here: [examples/webhooks](examples/webhooks/README.md). You can also refer to the [configuration syntax](docs/configuration_syntax.md) for more information.
 
 ## Usage
 


### PR DESCRIPTION
Changed "You can also refer to the configuration syntax for me information." to "You can also refer to the configuration syntax for more information."